### PR TITLE
适配 Minecraft 26.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,16 +7,16 @@ org.gradle.configuration-cache=false
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=26.1.2
-loader_version=0.19.2
-loom_version=1.16-SNAPSHOT
+minecraft_version=26.2
+loader_version=0.19.3
+loom_version=1.17.11
 
 # Mod Properties
-mod_version=1.6.2
+mod_version=1.6.3
 maven_group=kite.autoharvest
 archives_base_name=autoharvest
 
 # Dependencies
-fabric_api_version=0.149.1+26.1.2
-cloth_config_version=26.1.154
-modmenu_version=18.0.0-beta.1
+fabric_api_version=0.152.2+26.2
+cloth_config_version=26.2.155
+modmenu_version=20.0.0-beta.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/java/kite/autoharvest/mode/HarvestMode.java
+++ b/src/main/java/kite/autoharvest/mode/HarvestMode.java
@@ -54,7 +54,7 @@ public class HarvestMode implements AutoMode {
         int radiusInt = (int) Math.ceil(radius);
 
         for (BlockPos pos : BlockPos.withinManhattan(BlockPos.containing(playerPos), radiusInt, radiusInt, radiusInt)) {
-            if (!searchBox.contains(pos.getCenter())) continue;
+            if (!searchBox.contains(Vec3.atCenterOf(pos))) continue;
             if (BoxUtil.isOutsideSphere(pos, playerPos, radius)) continue;
 
             BlockState state = world.getBlockState(pos);

--- a/src/main/java/kite/autoharvest/mode/animal/Animals.java
+++ b/src/main/java/kite/autoharvest/mode/animal/Animals.java
@@ -44,7 +44,7 @@ public class Animals {
     private static Set<Item> getFlowerItems() {
         Set<Item> flowers = new HashSet<>();
         for (Item item : BuiltInRegistries.ITEM) {
-            if (new ItemStack(item).is(ItemTags.FLOWERS)) {
+            if (new ItemStack(item).is(ItemTags.BEE_FOOD)) {
                 flowers.add(item);
             }
         }

--- a/src/main/java/kite/autoharvest/util/BoxUtil.java
+++ b/src/main/java/kite/autoharvest/util/BoxUtil.java
@@ -33,14 +33,14 @@ public class BoxUtil {
     }
 
     public static boolean isOutsideSphere(BlockPos pos, Vec3 center, double radius) {
-        return !center.closerThan(pos.getCenter(), radius);
+        return !center.closerThan(Vec3.atCenterOf(pos), radius);
     }
 
     public static void forEachBlockInRange(Vec3 playerPos, double radius, Predicate<BlockPos> action) {
         AABB searchBox = createSearchBox(playerPos, radius);
         int radiusInt = (int) Math.ceil(radius);
         for (BlockPos pos : BlockPos.withinManhattan(BlockPos.containing(playerPos), radiusInt, radiusInt, radiusInt)) {
-            if (!searchBox.contains(pos.getCenter())) continue;
+            if (!searchBox.contains(Vec3.atCenterOf(pos))) continue;
             if (isOutsideSphere(pos, playerPos, radius)) continue;
             if (action.test(pos)) return;
         }

--- a/src/main/java/kite/autoharvest/util/InteractionHelper.java
+++ b/src/main/java/kite/autoharvest/util/InteractionHelper.java
@@ -19,7 +19,7 @@ public final class InteractionHelper {
     public static void interactBlock(LocalPlayer player, BlockPos blockPos, InteractionHand hand, Direction side) {
         Minecraft client = Minecraft.getInstance();
         if (client.gameMode == null) return;
-        Vec3 hitPos = blockPos.getCenter();
+        Vec3 hitPos = Vec3.atCenterOf(blockPos);
         BlockHitResult hitResult = new BlockHitResult(hitPos, side, blockPos, false);
         client.gameMode.useItemOn(player, hand, hitResult);
     }

--- a/src/main/java/kite/autoharvest/util/ItemRefillHelper.java
+++ b/src/main/java/kite/autoharvest/util/ItemRefillHelper.java
@@ -26,7 +26,7 @@ public class ItemRefillHelper {
     private static void doRefill(Minecraft client, HandType handType) {
         if (client.player == null || client.level == null) return;
 
-        if (client.screen != null && !(client.screen instanceof InventoryScreen)) {
+        if (client.gui.screen() != null && !(client.gui.screen() instanceof InventoryScreen)) {
             return;
         }
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -24,14 +24,14 @@
   },
   "mixins": [],
   "depends": {
-    "fabricloader": ">=0.17.3",
-    "minecraft": "26.1.x",
+    "fabricloader": ">=0.19.3",
+    "minecraft": "26.2",
     "java": ">=25",
     "fabric-api": "*",
-    "cloth-config": ">=26.1.154"
+    "cloth-config": ">=26.2.155"
   },
   "recommends": {
-    "modmenu": ">=18.0.0-beta.1"
+    "modmenu": ">=20.0.0-beta.2"
   },
   "suggests": {}
 }


### PR DESCRIPTION
## 修改内容

- 将 Minecraft 更新至 26.2
- 更新 Fabric Loader、Loom、Fabric API、Cloth Config、Mod Menu 和 Gradle
- 使用 Vec3.atCenterOf 替代已移除的 BlockPos#getCenter
- 使用 ItemTags.BEE_FOOD 适配蜜蜂食物标签
- 使用 client.gui.screen() 适配 26.2 GUI 调整

## 验证

- Java 25
- Gradle 9.5.1
- Fabric Loom 1.17.11
- .\gradlew.bat clean build --no-daemon：BUILD SUCCESSFUL
- Fabric Loader 0.19.3 客户端加载验证通过
- 已验证 Fabric API 0.152.1、Cloth Config 26.2.155、Mod Menu 20.0.0-beta.2